### PR TITLE
fix(ci): add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,12 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  id-token: write
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,13 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  actions: read
+  id-token: write
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -18,6 +18,9 @@ name: continuous
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu-latest:
     name: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ on:
     tags:
       - '\d+\.\d+\.\d+'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   ubuntu-latest:
     name: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds explicit top-level `permissions:` blocks to all four GitHub Actions workflow files, following the principle of least privilege. This reduces the blast radius if a workflow is ever compromised.

Fixes #22

## Changes per workflow

| Workflow | Permissions Added | Rationale |
|----------|------------------|-----------|
| `claude-code-review.yml` | `contents: read`, `pull-requests: read`, `issues: read`, `id-token: write` | Reviews PRs (read-only); needs `id-token` for Claude OAuth |
| `claude.yml` | `contents: read`, `pull-requests: read`, `issues: read`, `actions: read`, `id-token: write` | Responds to comments/issues (read-only); reads CI results; needs `id-token` for Claude OAuth |
| `continuous.yml` | `contents: read` | Build-and-test only; no write access needed |
| `release.yml` | `contents: read`, `packages: write` | Reads source to build; pushes NuGet packages to GitHub Packages |

## Notes

- `claude-code-review.yml` and `claude.yml` already had job-level `permissions` blocks; the new top-level block provides an additional layer of defense-in-depth
- `continuous.yml` and `release.yml` had no permissions declared at all and were inheriting the repository default

## Test plan

- [ ] Verify `continuous.yml` still passes on push events
- [ ] Verify `release.yml` can still publish packages on tag push
- [ ] Verify Claude Code workflows still respond to PR comments and reviews