### PR TITLE
Fix Claude Code Review workflow for bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'renovate[bot],dependabot[bot]'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Add `allowed_bots: 'renovate[bot],dependabot[bot]'` to the Claude Code Review workflow so it no longer rejects PRs opened by Renovate or Dependabot
- Upgrade `pull-requests` permission from `read` to `write` so the action can post review comments

## Root Cause

The `anthropics/claude-code-action@v1` action rejects workflow runs initiated by non-human actors (bots) by default. Every Renovate PR triggered the Claude Code Review workflow, which then failed with:

> Workflow initiated by non-human actor: renovate (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

## Note on release workflow

The `release` workflow's last failure (Dec 2025) was caused by an expired/invalid NuGet API key (403 from nuget.org). This is a secrets rotation issue that cannot be fixed via workflow YAML changes — the `NUGET_KEY` secret needs to be refreshed in the repository settings.

## Test plan

- [ ] Open or re-run a Renovate PR to verify the Claude Code Review action no longer fails
- [ ] Verify the action can post comments (write permission)

Fixes #21