### PR TITLE
fix(ci): AutoGenerate = false — Nuke ecrasait le travail de Renovate

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -11,9 +11,20 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 // ReSharper disable AllUnderscoreLocalParameterName
 
+// AutoGenerate = false : les workflows sous .github/workflows/ sont desormais la
+// SOURCE, et non plus un artefact regenere. Sans ce reglage, N'IMPORTE QUELLE cible
+// Nuke (y compris `./build.sh --help`) reecrit continuous.yml et release.yml et
+// ECRASE trois choses qui ne viennent pas du generateur :
+//   - les versions d'actions montees par Renovate (cache v5 -> v4, upload-artifact v7 -> v5) ;
+//   - le bloc `permissions: contents: read` (moindre privilege) ;
+//   - l'etape `Setup dotnet` qui epingle les SDK 8.0.x et 9.0.x.
+// Renovate a modifie continuous.yml 4 fois : son travail etait annule en silence.
+// Corollaire : une modification de ces attributs ne se propage plus toute seule,
+// il faut editer les .yml a la main -- c'est le prix, et c'est le but.
 [GitHubActions(
     "continuous",
     GitHubActionsImage.UbuntuLatest,
+    AutoGenerate = false,
     FetchDepth = 0,
     On = [GitHubActionsTrigger.Push],
     PublishArtifacts = true,
@@ -21,6 +32,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 [GitHubActions(
     "release",
     GitHubActionsImage.UbuntuLatest,
+    AutoGenerate = false,
     FetchDepth = 0,
     OnPushTags = [@"\d+\.\d+\.\d+"],
     PublishArtifacts = true,


### PR DESCRIPTION
## Le probleme, reproduit

L'attribut `[GitHubActions]` de Nuke regenere `.github/workflows/*.yml` a **chaque** execution, meme sur une cible inoffensive. Reproduit en copie scratch : `./build.sh --help` suffit, et il reecrit **les deux** workflows.

## La preuve du conflit

`renovate[bot]` a modifie `.github/workflows/continuous.yml` **4 fois sur 10 commits** :

| sha | bump |
|---|---|
| `490562f8` | `actions/upload-artifact` -> v7 (#19) |
| `409be3fb` | `actions/upload-artifact` -> v6 |
| `b3a72a52` | `actions/cache` -> v5 |
| `f4be4236` | `actions/checkout` -> v6 |

Chacun etait annule en silence des que quelqu'un lancait Nuke.

## Ce que la regeneration detruisait

Ce ne sont **pas** que des versions :

- `actions/cache` **v5 -> v4** (bump Renovate retrograde)
- `actions/upload-artifact` **v7 -> v5** (bump Renovate retrograde)
- le bloc **`permissions: contents: read` SUPPRIME** — moindre privilege perdu
- l'etape **`Setup dotnet` entiere SUPPRIMEE**, avec son epinglage `8.0.x` / `9.0.x`

Les deux dernieres pertes sont fonctionnelles et de securite.

## Oracle

Mesure par code de sortie **et** par `git status --porcelain -- .github/workflows` — jamais `git diff` seul, un fichier regenere pouvant se presenter en suppression + ajout non suivi.

| commande | avant | apres |
|---|---|---|
| `./build.sh --help` | 0, **2 workflows reecrits** | 0, **0 workflow touche** |
| `./build.sh Compile Pack` (cible reelle de la CI) | — | **0**, 0 workflow touche |

## Contrepartie assumee

Les `.yml` deviennent la **source**. Modifier les attributs `[GitHubActions]` ne se propagera plus tout seul : il faudra editer les workflows a la main. Un commentaire le dit sur place.

Aucune version n'est restauree ici : le depot porte deja les versions montees par Renovate. Le geste **empeche l'ecrasement futur**, il ne repare pas un ecrasement en cours.